### PR TITLE
Fix stack overflow in fromFoldable, fixes #3

### DIFF
--- a/src/Foreign/Object.purs
+++ b/src/Foreign/Object.purs
@@ -44,6 +44,7 @@ module Foreign.Object
 import Prelude
 
 import Control.Monad.ST (ST)
+import Control.Monad.ST as ST
 import Data.Array as A
 import Data.Eq (class Eq1)
 import Data.Foldable (class Foldable, foldl, foldr, for_)
@@ -216,7 +217,7 @@ update f k m = alter (maybe Nothing f) k m
 fromFoldable :: forall f a. Foldable f => f (Tuple String a) -> Object a
 fromFoldable l = runST do
   s <- OST.new
-  for_ (A.fromFoldable l) \(Tuple k v) -> OST.poke k v s
+  ST.foreach (A.fromFoldable l) \(Tuple k v) -> void $ OST.poke k v s
   pure s
 
 foreign import _lookupST :: forall a r z. Fn4 z (a -> z) String (STObject r a) (ST r z)


### PR DESCRIPTION
I had to rearrange things to remove that `where` clause in the tests
because otherwise I'd get a syntax error (still not entirely sure why,
but oh well).

The test I've added fails on `master` with compiler v0.12.3 and node
v8.10.0, but passes with the change to `fromFoldable`.