### PR TITLE
Relax upper bound of typelevel-prelude

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -31,7 +31,7 @@
     "purescript-tailrec": "^4.0.0",
     "purescript-tuples": "^5.0.0",
     "purescript-unfoldable": "^4.0.0",
-    "purescript-typelevel-prelude": "^4.0.0"
+    "purescript-typelevel-prelude": ">= 4.0.0 < 6.0.0"
   },
   "devDependencies": {
     "purescript-quickcheck": "^6.0.0",


### PR DESCRIPTION
We are only using Type.Row.Homogenous, which is not affected by the
v5.0.0 version bump, so relax the upper bound to allow both 4.x.x 5.x.x
of typelevel-prelude.