### PR TITLE
Add roles declarations to allow safe coercions

### DIFF
--- a/src/Foreign/Object.purs
+++ b/src/Foreign/Object.purs
@@ -64,6 +64,8 @@ import Unsafe.Coerce (unsafeCoerce)
 -- | `Object a` represents a homogeneous JS Object with values of type `a`.
 foreign import data Object :: Type -> Type
 
+type role Object representational
+
 foreign import _copyST :: forall a b r. a -> ST r b
 
 -- | Convert an immutable Object into a mutable Object

--- a/src/Foreign/Object/ST.purs
+++ b/src/Foreign/Object/ST.purs
@@ -24,6 +24,8 @@ import Data.Maybe (Maybe(..))
 -- | that of `Object a`, except that mutation is allowed.
 foreign import data STObject :: Region -> Type -> Type
 
+type role STObject nominal representational
+
 -- | Create a new, empty mutable object
 foreign import new :: forall a r. ST r (STObject r a)
 


### PR DESCRIPTION
This allows terms of type `Object a` and `STObject r a` to be coerced to type `Object b` and `STArray r b` when `Coercible a b` holds, hence allowing the zero cost `coerce` instead of `map wrap` and `map unwrap` to introduce and eliminate newtypes under objects and ST objects for instance.

I couldn’t think of a case where a phantom roled region is an issue but in doubt I preferred to keep it nominal.