### PR TITLE
Implement Semigroup via unionWith

### DIFF
--- a/src/Foreign/Object.purs
+++ b/src/Foreign/Object.purs
@@ -280,7 +280,7 @@ mapWithKey :: forall a b. (String -> a -> b) -> Object a -> Object b
 mapWithKey f m = runFn2 _mapWithKey m f
 
 instance semigroupObject :: (Semigroup a) => Semigroup (Object a) where
-  append m1 m2 = mutate (\s1 -> foldM (\s2 k v1 -> OST.poke k (runFn4 _lookup v1 (\v2 -> v1 <> v2) k m2) s2) s1 m1) m2
+  append = unionWith (<>)
 
 instance monoidObject :: (Semigroup a) => Monoid (Object a) where
   mempty = empty


### PR DESCRIPTION
We introduced a `unionWith :: forall a. (a -> a -> a) -> Object a -> Object a -> Object a` function in https://github.com/purescript/purescript-foreign-object/pull/21 that can be used to implement the Semigroup instance.